### PR TITLE
changes `date "%I"` behavior

### DIFF
--- a/src/other/date.js
+++ b/src/other/date.js
@@ -80,7 +80,10 @@ function date(date, formatString) {
             ret = zeroize(hours);
             break;
         case '%I':
-            ret = d.getHours() % 12;
+            var hours = d.getHours();
+            if (hours != 12)
+              hours = hours % 12;
+            ret = zeroize(hours);
             break;
         case '%j':
             ret = zeroize(getDays(), 3);


### PR DESCRIPTION
%I should return values between 00~11 when AM and values between 01~12 when PM.
most clocks show "12:00:00 PM" after "11:59:59 AM"